### PR TITLE
Add client headers when proxying API calls

### DIFF
--- a/src/components/GraphInstance.vue
+++ b/src/components/GraphInstance.vue
@@ -206,7 +206,8 @@ export default {
       if (!options.keepData) {
         this.data = await d3
           .json(`${this.settings.url}?geography=${geoParam}`)
-          .then(data => {
+          .then(rawData => {
+            const data = rawData[0];
             this.$emit('updateDate', data.meta.publishedDate);
 
             data.data.map(district => {


### PR DESCRIPTION
Axios doesn't pass "Accept-Encoding" headers on, so instead use node
http/https modules.