### PR TITLE
Update Keycloak server URL parameter name

### DIFF
--- a/server/auth/api.js
+++ b/server/auth/api.js
@@ -4,7 +4,7 @@ const axios = require('axios');
 const querystring = require('querystring');
 
 const envs = {
-  access_token_url: `${process.env.KEYCLOAK_URL}realms/${process.env.KEYCLOAK_REALM}/protocol/openid-connect/token`,
+  access_token_url: `${process.env.KEYCLOAK_SERVER_URL}/auth/realms/${process.env.KEYCLOAK_REALM}/protocol/openid-connect/token`,
 };
 
 const request = params => {


### PR DESCRIPTION
The `KEYCLOAK_URL` parameter has been deprecated in favor of the more general `KEYCLOAK_SERVER_URL`, which doesn't include the `/auth/` postfix. Update its usage.