### PR TITLE
Switch from `xmldom` to `@xmldom/xmldom`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3138,6 +3138,11 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@xmldom/xmldom": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.6.tgz",
+      "integrity": "sha512-uRjjusqpoqfmRkTaNuLJ2VohVr67Q5YwDATW3VU7PfzTj6IRaihGrYI7zckGZjxQPBIp63nfvJbM+Yu5ICh0Bg=="
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -19955,11 +19960,6 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
-    },
-    "xmldom": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@sentry/vue": "^6.7.2",
+    "@xmldom/xmldom": "^0.8.6",
     "axios": "^0.21.2",
     "canvas": "^2.8.0",
     "canvg": "^3.0.7",
@@ -40,8 +41,7 @@
     "vue-skip-to": "^1.0.6",
     "vue2-leaflet": "^2.7.0",
     "vuex": "^3.6.2",
-    "xlsx": "^0.17.0",
-    "xmldom": "^0.6.0"
+    "xlsx": "^0.17.0"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^4.5.13",


### PR DESCRIPTION
Switch from `xmldom` to `@xmldom/xmldom` to avoid a critical security issue in the former.

Resolves https://github.com/oslokommune/bydelsfakta/security/dependabot/44.