### PR TITLE
Fix map scales

### DIFF
--- a/src/config/topics/alder.js
+++ b/src/config/topics/alder.js
@@ -70,7 +70,6 @@ export default {
       },
       map: {
         labels: ['Lavere gjennomsnittsalder', 'Høyere gjennomsnittsalder'],
-        scale: [32, 43],
         reverse: true,
         method: 'avg',
         url: `${API}/alder-distribusjon-status`,

--- a/src/config/topics/husholdninger.js
+++ b/src/config/topics/husholdninger.js
@@ -21,7 +21,6 @@ export default {
         url: `${API}/husholdningstyper-status`,
         heading: 'Énpersonshusholdninger',
         method: 'ratio',
-        series: 0,
       },
       tabs: [
         {


### PR DESCRIPTION
The map coloring scales have been totally misleading. Revamp the whole implementation to make them (hopefully) make more sense.

The scales are now linear from 0% to 200% compared to the Oslo average (so that 100% = the Oslo average = the middle of the scale). The (few) values above 200% are simply clamped down to 200%.